### PR TITLE
Thread safe library config vars

### DIFF
--- a/lib/hoalife.rb
+++ b/lib/hoalife.rb
@@ -25,16 +25,7 @@ require 'hoalife/error'
 
 # :nodoc
 module HOALife
-  @api_base                = ENV.fetch('HOALIFE_API_BASE', 'https://api.hoalife.com/api')
-  @api_version             = ENV.fetch('HOALIFE_API_VERSION', '1').to_i
-  @api_key                 = ENV['HOALIFE_API_KEY']
-  @signing_secret          = ENV['HOALIFE_SIGNING_SECRET']
-  @sleep_when_rate_limited = 10.0
-
   class << self
-    attr_accessor :api_key, :signing_secret, :api_base, :api_version,
-                  :sleep_when_rate_limited
-
     # Support configuring with a block
     # HOALife.config do |config|
     #  config.api_key = "foo"
@@ -44,5 +35,24 @@ module HOALife
     def config
       yield self
     end
+
+    def thread_local_var(key, default_value = nil)
+      Thread.current[key] = default_value
+
+      define_singleton_method(key) do
+        Thread.current[key]
+      end
+
+      define_singleton_method("#{key}=") do |value|
+        Thread.current[key] = value
+      end
+    end
   end
+
+  thread_local_var :api_key, ENV['HOALIFE_API_KEY']
+  thread_local_var :signing_secret, ENV['HOALIFE_SIGNING_SECRET']
+
+  thread_local_var :api_base, ENV.fetch('HOALIFE_API_BASE', 'https://api.hoalife.com/api')
+  thread_local_var :api_version, ENV.fetch('HOALIFE_API_VERSION', '1').to_i
+  thread_local_var :sleep_when_rate_limited, 10.0
 end

--- a/test/hoalife_test.rb
+++ b/test/hoalife_test.rb
@@ -10,4 +10,27 @@ class HOALifeTest < HOALifeBaseTest
 
     assert_equal 'foo', HOALife.api_key
   end
+
+  def test_thread_safe_config
+    threads = []
+
+    100.times do |i|
+      threads << Thread.new do
+        HOALife.config do |c|
+          c.api_key = "foo#{i}"
+        end
+
+        HOALife.signing_secret = "bar#{i}"
+        puts "assigned foo#{i}, bar#{i}"
+
+        sleep rand
+
+        assert_equal "foo#{i}", HOALife.api_key
+        assert_equal "bar#{i}", HOALife.signing_secret
+        puts "asserted foo#{i}, bar#{i}"
+      end
+    end
+
+    threads.each(&:join)
+  end
 end


### PR DESCRIPTION
Sharing state works fine in a single thread, but falls on its face when the library is used in multiple threads.

Use `Thread.current` to store the config variables while maintaing the same API.