### PR TITLE
Change the env key used for hot-reloading classes

### DIFF
--- a/lib/hoalife.rb
+++ b/lib/hoalife.rb
@@ -10,7 +10,7 @@ tests = "#{__dir__}/**/*_test.rb"
 loader.ignore(tests)
 # loader.log!
 
-if ENV['DEV']
+if ENV['HOALIFE_RUBY_DEV']
   require 'listen'
 
   loader.enable_reloading


### PR DESCRIPTION
Avoid conflict with other ENV keys accidently enabling reloading outside of the gem development environemnet.