### PR TITLE
Use more unique Thread.current variable names

### DIFF
--- a/lib/hoalife.rb
+++ b/lib/hoalife.rb
@@ -37,14 +37,16 @@ module HOALife
     end
 
     def thread_local_var(key, default_value = nil)
-      Thread.current[key] = default_value
+      current_key = "HOALIFE_RUBY_#{key}"
+
+      Thread.current[current_key] = default_value
 
       define_singleton_method(key) do
-        Thread.current[key]
+        Thread.current[current_key]
       end
 
       define_singleton_method("#{key}=") do |value|
-        Thread.current[key] = value
+        Thread.current[current_key] = value
       end
     end
   end


### PR DESCRIPTION
Use more unique `Thread.current` variable names to avoid conflicts with other libraries which might use similar variable names.